### PR TITLE
add support for interactive data visualization for fprime channels & events

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This repo provides an Immutable-Infrastructure-as-Code (IIaC) workspace for the 
     - [Jupyter Notebook](https://jupyter.org/)
     - [Voilà](https://voila.readthedocs.io/en/stable/index.html)
     - [Pint](https://pint.readthedocs.io/en/stable/)
+- [Pharo Launcher](https://github.com/pharo-project/pharo-launcher) with following [https://pharo.org/web/](Pharo) images
+    - "RoassalPlayground" pre-loaded with
+        - [Roassal3](https://github.com/ObjectProfile/Roassal3) v1.01b
+        - [NeoCSV](https://github.com/svenvc/NeoCSV)
+        - [XMLParser](https://github.com/pharo-contributions/XML-XMLParser)
+        - [Roassal3Exporters](github://ObjectProfile/Roassal3Exporters) v1.0
 - [QOwnNotes](https://www.qownnotes.org/) 23.12.5 (built from source)
 - VS Code with the following extensions (note, auto-updates are disabled)
     - [Python extension by Microsoft](https://marketplace.visualstudio.com/items?itemName=ms-python.python)

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -344,42 +344,42 @@
   - name: Clone PharoLauncher
     shell:
       cmd: git clone https://github.com/pharo-project/pharo-launcher.git
-      chdir: /opt
+      chdir: /home/kasm-default-profile
       executable: /bin/bash
   - name: Checkout {{ pharo_launcher_version }} in pharo-launcher repo
     shell:
       cmd: git checkout {{ pharo_launcher_version }}
-      chdir: /opt/pharo-launcher
+      chdir: /home/kasm-default-profile/pharo-launcher
       executable: /bin/bash
   - name: Download Pharo {{ pharo_version }} + VM in pharo-launcher
     shell:
       cmd: curl https://get.pharo.org/{{ pharo_version }}0+vm | bash
-      chdir: /opt/pharo-launcher
+      chdir: /home/kasm-default-profile/pharo-launcher
       executable: /bin/bash
   - name: Rename Pharo.image to PharoLauncher.image
     shell:
       cmd: mv Pharo.image PharoLauncher.image
-      chdir: /opt/pharo-launcher
+      chdir: /home/kasm-default-profile/pharo-launcher
       executable: /bin/bash
   - name: Load PharoLauncher with Metachello from shell  # as per https://github.com/pharo-project/pharo-launcher/blob/feature/cmd-line/build.sh#L31C2-L31C183
     shell:
       cmd: ./pharo PharoLauncher.image eval --save "Metacello new baseline{{ ':' }} 'PharoLauncher'; repository{{ ':' }} 'gitlocal{{ ':' }}//src'; ignoreImage; onConflictUseIncoming; onWarning{{ ':' }} [{{ ':' }}ex | ex load]; load"
-      chdir: /opt/pharo-launcher
+      chdir: /home/kasm-default-profile/pharo-launcher
       executable: /bin/bash
   - name: Configure pharo-launcher bash script
-    shell: echo "#!/usr/bin/env bash\n/opt/pharo-launcher/pharo-ui /opt/pharo-launcher/PharoLauncher.image eval 'PharoLauncherApplication openFull'" > /home/kasm-default-profile/install_files/pharo-launcher
-  - name: Copy pharo-launcher bash script into /opt/pharo-launcher and set to executable
+    shell: echo "#!/usr/bin/env bash\n/home/kasm-default-profile/pharo-launcher/pharo-ui /home/kasm-default-profile/pharo-launcher/PharoLauncher.image eval 'PharoLauncherApplication openFull'" > /home/kasm-default-profile/install_files/pharo-launcher
+  - name: Copy pharo-launcher bash script into /home/kasm-default-profile/pharo-launcher and set to executable
     copy:
       src: /home/kasm-default-profile/install_files/pharo-launcher
-      dest: /opt/pharo-launcher
+      dest: /home/kasm-default-profile/pharo-launcher
       remote_src: yes
       owner: root
       group: root
       mode: a+x
   - name: Create symlink for pharo-launcher in /usr/local/bin
-    shell: ln -sv /opt/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
+    shell: ln -sv /home/kasm-default-profile/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
   - name: Configure PharoLauncher desktop shortcut
-    shell: echo "[Desktop Entry]\nName=Pharo\nGenericName=Pharo\nExec=pharo-launcher\nIcon=/opt/pharo-launcher/icons/pharo-launcher.png\nTerminal=false\nType=Application\nStartupNotify=false\nCategories=Application;Development;" > /usr/share/applications/pharo.desktop
+    shell: echo "[Desktop Entry]\nName=Pharo\nGenericName=Pharo\nExec=pharo-launcher\nIcon=/home/kasm-default-profile/pharo-launcher/icons/pharo-launcher.png\nTerminal=false\nType=Application\nStartupNotify=false\nCategories=Application;Development;" > /usr/share/applications/pharo.desktop
 
 - 
   # install sudo for the vs-code role below 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -390,6 +390,7 @@
     pharo_launcher_version: "c661cf8e517bf2695fb637aa058d7fab3449107a"
     pharo_version: "10"
     roassal_version: "v1.01b"
+    neocsv_version: "fcffa0bba57b2c8c4624eb356fd29afc9b3dbf4a"
 
   tasks:
   - name: Clone PharoLauncher
@@ -467,6 +468,24 @@
   - name: Load Full Roassal3 package into RoassalPlayground using Metacello
     shell:
       cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'Roassal3'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-graphics/Roassal/src'; load{{ ':' }} 'Full'] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
+  - name: Create directory for svenvc/NeoCSV in RoassalPlayground/pharo-local/iceberg
+    shell:
+      cmd: mkdir svenvc
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/
+  - name: Clone NeoCSV into RoassalPlayground/pharo-local/iceberg/svenvc
+    shell:
+      cmd: git clone https://github.com/svenvc/NeoCSV.git
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/svenvc
+  - name: Checkout {{ neocsv_version }} in NeoCSV repo
+    shell:
+      cmd: git checkout {{ neocsv_version }}
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/svenvc/NeoCSV
+      executable: /bin/bash
+  - name: Load NeoCSV package into RoassalPlayground using Metacello
+    shell:
+      cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'NeoCSV'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/svenvc/NeoCSV/repository'; load] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -387,6 +387,7 @@
     pharo_launcher_version: "c661cf8e517bf2695fb637aa058d7fab3449107a"
     pharo_version: "11"
     roassal_version: "v1.01b"
+    roassalexporter_version: "v1.0"
     neocsv_version: "fcffa0bba57b2c8c4624eb356fd29afc9b3dbf4a"
     xmlparser_version: "531f9b7c711c89e51ac54cb878099f5a89bca50e"
 
@@ -473,7 +474,7 @@
       cmd: ./pharo RoassalPlayground.image eval --save "PharoDarkTheme beCurrent"
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
-  - name: Load Full Roassal3 package into RoassalPlayground using Metacello
+  - name: Load Full Roassal3 package from local repo into RoassalPlayground using Metacello
     shell:
       cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'Roassal3'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-graphics/Roassal/src'; load{{ ':' }} 'Full'] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
@@ -491,7 +492,7 @@
       cmd: git checkout {{ neocsv_version }}
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/svenvc/NeoCSV
       executable: /bin/bash
-  - name: Load NeoCSV package into RoassalPlayground using Metacello
+  - name: Load NeoCSV package from local repo into RoassalPlayground using Metacello
     shell:
       cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'NeoCSV'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/svenvc/NeoCSV/repository'; load] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
@@ -505,9 +506,23 @@
       cmd: git checkout {{ xmlparser_version }}
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-contributions/XML-XMLParser
       executable: /bin/bash
-  - name: Load XMLParser package into RoassalPlayground using Metacello
+  - name: Load XMLParser package from local repo into RoassalPlayground using Metacello
     shell:
       cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'XMLParser'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-contributions/XML-XMLParser/src'; load] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
+  - name: Clone Roassal3Exporters into RoassalPlayground/pharo-local/iceberg/pharo-contributions
+    shell:
+      cmd: git clone https://github.com/ObjectProfile/Roassal3Exporters
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-contributions
+  - name: Checkout {{ roassalexporter_version }} in Roassal3Exporters repo
+    shell:
+      cmd: git checkout {{ roassalexporter_version }}
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-contributions/Roassal3Exporters
+      executable: /bin/bash
+  - name: Load Roassal3Exporters package from local repo into RoassalPlayground using Metacello
+    shell:
+      cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'Roassal3Exporters'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-contributions/Roassal3Exporters/src'; load] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -338,6 +338,7 @@
 
   vars:
     pharo_launcher_version: "3.1.1"
+    pharo_version: "10"
 
   tasks:
   - name: Clone PharoLauncher
@@ -350,9 +351,9 @@
       cmd: git checkout {{ pharo_launcher_version }}
       chdir: /opt/pharo-launcher
       executable: /bin/bash
-  - name: Download Pharo 11.0 + VM in pharo-launcher
+  - name: Download Pharo {{ pharo_version }} + VM in pharo-launcher
     shell:
-      cmd: curl https://get.pharo.org/110+vm | bash
+      cmd: curl https://get.pharo.org/{{ pharo_version }}0+vm | bash
       chdir: /opt/pharo-launcher
       executable: /bin/bash
   - name: Rename Pharo.image to PharoLauncher.image

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -338,7 +338,7 @@
 
   vars:
     pharo_launcher_version: "3.1.1"
-    pharo_version: "10"
+    pharo_version: "11"
 
   tasks:
   - name: Clone PharoLauncher

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -338,7 +338,7 @@
 
   vars:
     pharo_launcher_version: "3.1.1"
-    pharo_version: "11"
+    pharo_version: "10"
 
   tasks:
   - name: Clone PharoLauncher

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -380,15 +380,12 @@
   # Install Pharo
   hosts: localhost
   connection: local
-  environment:
-    PHARO: 110
-    ARCHITECTURE: 64
   tags:
     - install_pharo
 
   vars:
     pharo_launcher_version: "c661cf8e517bf2695fb637aa058d7fab3449107a"
-    pharo_version: "10"
+    pharo_version: "11"
     roassal_version: "v1.01b"
     neocsv_version: "fcffa0bba57b2c8c4624eb356fd29afc9b3dbf4a"
     xmlparser_version: "531f9b7c711c89e51ac54cb878099f5a89bca50e"
@@ -404,7 +401,7 @@
       cmd: git checkout {{ pharo_launcher_version }}
       chdir: /home/kasm-default-profile/pharo-launcher
       executable: /bin/bash
-  - name: Download Pharo {{ pharo_version }} + VM in pharo-launcher
+  - name: Download Pharo {{ pharo_version }} image + vm in pharo-launcher
     shell:
       cmd: curl https://get.pharo.org/{{ pharo_version }}0+vm | bash
       chdir: /home/kasm-default-profile/pharo-launcher
@@ -451,9 +448,9 @@
       cmd: git checkout {{ roassal_version }}
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-graphics/Roassal
       executable: /bin/bash
-  - name: Download Pharo image + vm into RoassalPlayground
+  - name: Download Pharo {{ pharo_version }} image + vm into RoassalPlayground
     shell:
-      cmd: curl https://get.pharo.org/110+vm | bash
+      cmd: curl https://get.pharo.org/{{ pharo_version }}0+vm | bash
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
   - name: Rename Pharo.changes to RoassalPlayground.changes

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -416,6 +416,11 @@
       cmd: ./pharo PharoLauncher.image eval --save "Metacello new baseline{{ ':' }} 'PharoLauncher'; repository{{ ':' }} 'gitlocal{{ ':' }}//src'; ignoreImage; onConflictUseIncoming; onWarning{{ ':' }} [{{ ':' }}ex | ex load]; load"
       chdir: /home/kasm-default-profile/pharo-launcher
       executable: /bin/bash
+  - name: Enable PharoDarkTheme in PharoLauncher
+    shell:
+      cmd: ./pharo PharoLauncher.image eval --save "PharoDarkTheme beCurrent"
+      chdir: /home/kasm-default-profile/pharo-launcher
+      executable: /bin/bash
   - name: Configure pharo-launcher bash script
     shell: echo "#!/usr/bin/env bash\n/home/kasm-default-profile/pharo-launcher/pharo-ui /home/kasm-default-profile/pharo-launcher/PharoLauncher.image eval 'PharoLauncherApplication openFull'" > /home/kasm-default-profile/install_files/pharo-launcher
   - name: Copy pharo-launcher bash script into /home/kasm-default-profile/pharo-launcher and set to executable

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -377,7 +377,7 @@
       group: root
       mode: a+x
   - name: Create symlink for pharo-launcher in /usr/local/bin
-    shell: ln -srv /opt/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
+    shell: ln -sv /opt/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
   - name: Configure PharoLauncher desktop shortcut
     shell: echo "[Desktop Entry]\nName=Pharo\nGenericName=Pharo\nExec=pharo-launcher\nIcon=/opt/pharo-launcher/icons/pharo-launcher.png\nTerminal=false\nType=Application\nStartupNotify=false\nCategories=Application;Development;" > /usr/share/applications/pharo.desktop
 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -336,15 +336,18 @@
   tags:
     - install_pharo
 
+  vars:
+    pharo_launcher_version: "3.1.1"
+
   tasks:
   - name: Clone PharoLauncher
     shell:
       cmd: git clone https://github.com/pharo-project/pharo-launcher.git
       chdir: /opt
       executable: /bin/bash
-  - name: Checkout feature/cmd-line branch in pharo-launcher
+  - name: Checkout {{ pharo_launcher_version }} in pharo-launcher repo
     shell:
-      cmd: git checkout feature/cmd-line
+      cmd: git checkout {{ pharo_launcher_version }}
       chdir: /opt/pharo-launcher
       executable: /bin/bash
   - name: Download Pharo 11.0 + VM in pharo-launcher
@@ -357,7 +360,7 @@
       cmd: mv Pharo.image PharoLauncher.image
       chdir: /opt/pharo-launcher
       executable: /bin/bash
-  - name: Build PharoLauncher # as per https://github.com/pharo-project/pharo-launcher/blob/feature/cmd-line/build.sh#L31C2-L31C183
+  - name: Load PharoLauncher with Metachello from shell  # as per https://github.com/pharo-project/pharo-launcher/blob/feature/cmd-line/build.sh#L31C2-L31C183
     shell:
       cmd: ./pharo PharoLauncher.image eval --save "Metacello new baseline{{ ':' }} 'PharoLauncher'; repository{{ ':' }} 'gitlocal{{ ':' }}//src'; ignoreImage; onConflictUseIncoming; onWarning{{ ':' }} [{{ ':' }}ex | ex load]; load"
       chdir: /opt/pharo-launcher

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -466,6 +466,11 @@
       cmd: mv Pharo.image RoassalPlayground.image
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
+  - name: Enable PharoDarkTheme in RoassalPlayground
+    shell:
+      cmd: ./pharo RoassalPlayground.image eval --save "PharoDarkTheme beCurrent"
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
   - name: Load Full Roassal3 package into RoassalPlayground using Metacello
     shell:
       cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'Roassal3'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-graphics/Roassal/src'; load{{ ':' }} 'Full'] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -337,7 +337,7 @@
     - install_pharo
 
   vars:
-    pharo_launcher_version: "3.1.1"
+    pharo_launcher_version: "c661cf8e517bf2695fb637aa058d7fab3449107a"
     pharo_version: "10"
 
   tasks:

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -108,7 +108,9 @@
   hosts: localhost
   connection: local
   gather_facts: yes
-  tags: install_utilities
+  tags:
+    - install_utilities
+    - install_pharo
 
   vars:
     git_version: "2.43.0"
@@ -118,6 +120,10 @@
     keychain_version_expected: "{{ keychain_version }}.."
 
   tasks:
+  - name: Install unzip
+    apt:
+      name: unzip
+      update_cache: yes
   - name: Add git PPA
     shell: add-apt-repository ppa:git-core/ppa
   - name: Install git
@@ -319,6 +325,55 @@
       cmd: qmake && make
       chdir: /home/kasm-default-profile/install_files/qownnotes-{{ qownnotes_version }}
       executable: /bin/bash
+
+-
+  # Install Pharo
+  hosts: localhost
+  connection: local
+  environment:
+    PHARO: 110
+    ARCHITECTURE: 64
+  tags:
+    - install_pharo
+
+  tasks:
+  - name: Clone PharoLauncher
+    shell:
+      cmd: git clone https://github.com/pharo-project/pharo-launcher.git
+      chdir: /opt
+      executable: /bin/bash
+  - name: Checkout feature/cmd-line branch in pharo-launcher
+    shell:
+      cmd: git checkout feature/cmd-line
+      chdir: /opt/pharo-launcher
+      executable: /bin/bash
+  - name: Download Pharo 11.0 + VM in pharo-launcher
+    shell:
+      cmd: curl https://get.pharo.org/110+vm | bash
+      chdir: /opt/pharo-launcher
+      executable: /bin/bash
+  - name: Rename Pharo.image to PharoLauncher.image
+    shell:
+      cmd: mv Pharo.image PharoLauncher.image
+      chdir: /opt/pharo-launcher
+      executable: /bin/bash
+  - name: Build PharoLauncher # as per https://github.com/pharo-project/pharo-launcher/blob/feature/cmd-line/build.sh#L31C2-L31C183
+    shell:
+      cmd: ./pharo PharoLauncher.image eval --save "Metacello new baseline{{ ':' }} 'PharoLauncher'; repository{{ ':' }} 'gitlocal{{ ':' }}//src'; ignoreImage; onConflictUseIncoming; onWarning{{ ':' }} [{{ ':' }}ex | ex load]; load"
+      chdir: /opt/pharo-launcher
+      executable: /bin/bash
+  - name: Configure pharo-launcher bash script
+    shell: echo "#!/usr/bin/env bash\n/opt/pharo-launcher/pharo-ui /opt/pharo-launcher/PharoLauncher.image eval 'PharoLauncherApplication openFull'" > /home/kasm-default-profile/install_files/pharo-launcher
+  - name: Copy pharo-launcher bash script into /opt/pharo-launcher and set to executable
+    copy:
+      src: /home/kasm-default-profile/install_files/pharo-launcher
+      dest: /opt/pharo-launcher
+      remote_src: yes
+      owner: root
+      group: root
+      mode: a+x
+  - name: Create symlink for pharo-launcher in /usr/local/bin
+    shell: ln -srv /opt/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
 
 - 
   # install sudo for the vs-code role below 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -391,6 +391,7 @@
     pharo_version: "10"
     roassal_version: "v1.01b"
     neocsv_version: "fcffa0bba57b2c8c4624eb356fd29afc9b3dbf4a"
+    xmlparser_version: "531f9b7c711c89e51ac54cb878099f5a89bca50e"
 
   tasks:
   - name: Clone PharoLauncher
@@ -486,6 +487,20 @@
   - name: Load NeoCSV package into RoassalPlayground using Metacello
     shell:
       cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'NeoCSV'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/svenvc/NeoCSV/repository'; load] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
+  - name: Clone XML-XMLParser into RoassalPlayground/pharo-local/iceberg/pharo-contributions
+    shell:
+      cmd: git clone https://github.com/pharo-contributions/XML-XMLParser.git
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-contributions
+  - name: Checkout {{ xmlparser_version }} in NeoCSV repo
+    shell:
+      cmd: git checkout {{ xmlparser_version }}
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-contributions/XML-XMLParser
+      executable: /bin/bash
+  - name: Load XMLParser package into RoassalPlayground using Metacello
+    shell:
+      cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'XMLParser'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-contributions/XML-XMLParser/src'; load] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
       chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -339,6 +339,7 @@
   vars:
     pharo_launcher_version: "c661cf8e517bf2695fb637aa058d7fab3449107a"
     pharo_version: "10"
+    roassal_version: "v1.01b"
 
   tasks:
   - name: Clone PharoLauncher
@@ -380,10 +381,43 @@
     shell: ln -sv /home/kasm-default-profile/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
   - name: Configure PharoLauncher desktop shortcut
     shell: echo "[Desktop Entry]\nName=Pharo\nGenericName=Pharo\nExec=pharo-launcher\nIcon=/home/kasm-default-profile/pharo-launcher/icons/pharo-launcher.png\nTerminal=false\nType=Application\nStartupNotify=false\nCategories=Application;Development;" > /usr/share/applications/pharo.desktop
-  - name: Install Roassal with PharoLaucher-CLI
+  - name: Create RoassalPlayground (pharo image) using PharoLaucher-CLI
     shell:
       cmd: ./pharo PharoLauncher.image clap launcher image create fromRepo --newImageName RoassalPlayground pharo-graphics/Roassal
       chdir: /home/kasm-default-profile/pharo-launcher
+      executable: /bin/bash
+  - name: Change remote origin to https://github.com/ObjectProfile/Roassal3.git
+    shell:
+      cmd: git remote set-url origin https://github.com/ObjectProfile/Roassal3.git
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-graphics/Roassal
+  - name: Fetch upstream in Roassal repo
+    shell:
+      cmd: git fetch
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-graphics/Roassal
+  - name: Checkout {{ roassal_version }} in Roassal repo
+    shell:
+      cmd: git checkout {{ roassal_version }}
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground/pharo-local/iceberg/pharo-graphics/Roassal
+      executable: /bin/bash
+  - name: Download Pharo image + vm into RoassalPlayground
+    shell:
+      cmd: curl https://get.pharo.org/110+vm | bash
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
+  - name: Rename Pharo.changes to RoassalPlayground.changes
+    shell:
+      cmd: mv Pharo.changes RoassalPlayground.changes
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
+  - name: Rename Pharo.image to RoassalPlayground.image
+    shell:
+      cmd: mv Pharo.image RoassalPlayground.image
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
+      executable: /bin/bash
+  - name: Load Full Roassal3 package into RoassalPlayground using Metacello
+    shell:
+      cmd: ./pharo RoassalPlayground.image eval --save "[Metacello new baseline{{ ':' }} 'Roassal3'; repository{{ ':' }} 'gitlocal{{ ':' }}//./pharo-local/iceberg/pharo-graphics/Roassal/src'; load{{ ':' }} 'Full'] on{{ ':' }} MCMergeOrLoadWarning do{{ ':' }} [:warning | warning load ]"
+      chdir: /home/kasm-default-profile/Pharo/images/RoassalPlayground
       executable: /bin/bash
 
 - 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -374,6 +374,8 @@
       mode: a+x
   - name: Create symlink for pharo-launcher in /usr/local/bin
     shell: ln -srv /opt/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
+  - name: Configure PharoLauncher desktop shortcut
+    shell: echo "[Desktop Entry]\nName=Pharo\nGenericName=Pharo\nExec=pharo-launcher\nIcon=/opt/pharo-launcher/icons/pharo-launcher.png\nTerminal=false\nType=Application\nStartupNotify=false\nCategories=Application;Development;" > /usr/share/applications/pharo.desktop
 
 - 
   # install sudo for the vs-code role below 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -380,6 +380,11 @@
     shell: ln -sv /home/kasm-default-profile/pharo-launcher/pharo-launcher /usr/local/bin/pharo-launcher
   - name: Configure PharoLauncher desktop shortcut
     shell: echo "[Desktop Entry]\nName=Pharo\nGenericName=Pharo\nExec=pharo-launcher\nIcon=/home/kasm-default-profile/pharo-launcher/icons/pharo-launcher.png\nTerminal=false\nType=Application\nStartupNotify=false\nCategories=Application;Development;" > /usr/share/applications/pharo.desktop
+  - name: Install Roassal with PharoLaucher-CLI
+    shell:
+      cmd: ./pharo PharoLauncher.image clap launcher image create fromRepo --newImageName RoassalPlayground pharo-graphics/Roassal
+      chdir: /home/kasm-default-profile/pharo-launcher
+      executable: /bin/bash
 
 - 
   # install sudo for the vs-code role below 

--- a/reset_kasm_user.sh
+++ b/reset_kasm_user.sh
@@ -4,3 +4,5 @@ mv ./kasm_user/_README ./_README
 rm -rf ./kasm_user/*
 rm -rf ./kasm_user/.*
 mv ./_README ./kasm_user/_README
+
+docker system prune


### PR DESCRIPTION
Installs Roassal (pharo image) with NeoCSV such that it can be opened from pharo launcher

closes #22 

should merge #28 first, then rebase this PR off `main`, as to test if Roassal can read time-series data cached from fprime