### PR TITLE
Add FPrime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repo provides an Immutable-Infrastructure-as-Code (IIaC) workspace for the 
 - Open Source Hardware tools
     - [PrusaSlicer](https://github.com/prusa3d/PrusaSlicer) 2.7.0
     - [OpenSCAD](https://openscad.org/) 2021.01
+    - [FPrime (tools installed via fprime-workspace-image)](https://github.com/fprime-community/fprime-workspace-image) v3.4.0-rc1.1.0
 
 ## Requirements
 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -108,7 +108,9 @@
   hosts: localhost
   connection: local
   gather_facts: yes
-  tags: install_utilities
+  tags:
+    - install_utilities
+    - install_fprime
 
   vars:
     git_version: "2.43.0"
@@ -164,6 +166,50 @@
     get_url:
       url: https://gist.githubusercontent.com/capsulecorplab/401ba2fe0857a328f2a626adbf078cc6/raw/b89a6234f0d620ff60bcfe37f95de197b8772377/.gitconfig
       dest: /home/kasm-default-profile/
+
+-
+  # install fprime tools
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  tags:
+    - install_fprime
+
+  vars:
+    fprime_workspace_image_version: v3.4.0-rc1.1.0
+
+  tasks:
+  - name: Get ansible version (in ansible)
+    shell:
+      cmd: ansible --version
+      executable: /bin/bash
+    register: installed_ansible_version
+  - name: Get ansible-playbook version (in ansible)
+    shell:
+      cmd: ansible-playbook --version
+      executable: /bin/bash
+    register: installed_ansible_playbook_version
+  - name: Display ansible version
+    debug:
+      msg: ansible = {{ installed_ansible_version.stdout }}
+  - name: Display ansible-playbook version
+    debug:
+      msg: ansible = {{ installed_ansible_playbook_version.stdout }}
+  - name: Clone fprime-workspace-image
+    shell:
+      cmd: git clone https://github.com/fprime-community/fprime-workspace-image.git
+      chdir: /home/kasm-default-profile/install_files
+      executable: /bin/bash
+  - name: Checkout {{ fprime_workspace_image_version }} in fprime-workspace-image repo
+    shell:
+      cmd: git checkout {{ fprime_workspace_image_version }}
+      chdir: /home/kasm-default-profile/install_files/fprime-workspace-image
+      executable: /bin/bash
+  - name: Install fprime tools with ansible-galaxy
+    shell:
+      cmd: ansible-galaxy install -r requirements.yaml && ansible-playbook -i,localhost playbook.yaml --tags "install_fprime_tools" && rm -f ./*.yaml
+      chdir: /home/kasm-default-profile/install_files/fprime-workspace-image
+      executable: /bin/bash
 
 -
   # install PrusaSlicer

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -205,6 +205,11 @@
       cmd: git checkout {{ fprime_workspace_image_version }}
       chdir: /home/kasm-default-profile/install_files/fprime-workspace-image
       executable: /bin/bash
+  - name: Copy contents of fprime-workspace-image/install_files into install_files
+    shell:
+      cmd: cp -rf fprime-workspace-image/install_files/* .
+      chdir: /home/kasm-default-profile/install_files
+      executable: /bin/bash
   - name: Install fprime tools with ansible-galaxy
     shell:
       cmd: ansible-galaxy install -r requirements.yaml && ansible-playbook -i,localhost playbook.yaml --tags "install_fprime_tools" && rm -f ./*.yaml


### PR DESCRIPTION
closes #21 

## Testing procedure
1. clone or download `fleet-workspace-image` repo (if not already cloned) into home directory
```sh
cd ~
git clone https://github.com/capsulecorplab/mdrs-workspace-image.git
```
2. change directory to `mdrs-workspace-image` repo
```sh
cd ~/mdrs-workspace-image
```
3. change `:main` to `:pr-28` on image name in `docker-compose.yml`
4. pull docker image with `docker-compose pull` (this may take a few minutes)
5. spin up docker image with `docker-compose up`
6. log into kasm image by going to `https://localhost:6901` in a web browser and enter credentials
7. Recursively clone [fprime-baremetal-reference](https://github.com/fprime-community/fprime-baremetal-reference)
```sh
cd ~
git clone --recursive https://github.com/fprime-community/fprime-baremetal-reference.git
```
8. Checkout `fprime3.4.0` branch in `fprime-baremetal-reference` repo
```sh
cd ~/fprime-baremetal-reference
git checkout fprime3.4.0
```
9. Initialize submodules in `fprime-baremetal-reference` repo
```sh
cd ~/fprime-baremetal-reference
git submodules update --init --recursive
```
10. Checkout `fprime3.4.0` branch in `fprime-baremetal-reference/lib/arduino/fprime-arduino` submodule
cd ~/fprime-baremetal-reference/lib/arduino/fprime-arduino
git checkout fprime3.4.0
11. Generate fprime build cache in `fprime-baremetal-reference` repo
```sh
cd ~/fprime-baremetal-reference
fprime-util generate
```
12. Run build in `fprime-baremetal-reference` repo
```sh
cd ~/fprime-baremetal-reference
fprime-util build -j4
```